### PR TITLE
Invert display status logic

### DIFF
--- a/components/haier/haier_climate.cpp
+++ b/components/haier/haier_climate.cpp
@@ -193,11 +193,6 @@ bool HaierClimate::get_display_state() const
     return mDisplayStatus;
 }
 
-void HaierClimate::set_outdoor_temperature_sensor(esphome::sensor::Sensor *sensor) 
-{
-    mOutdoorSensor = sensor; 
-}
-
 void HaierClimate::set_display_state(bool state)
 {
     if (mDisplayStatus != state)
@@ -205,6 +200,11 @@ void HaierClimate::set_display_state(bool state)
         mDisplayStatus = state;
         mForceSendControl = true;
     }
+}
+
+void HaierClimate::set_outdoor_temperature_sensor(esphome::sensor::Sensor *sensor) 
+{
+    mOutdoorSensor = sensor; 
 }
 
 AirflowVerticalDirection HaierClimate::get_vertical_airflow() const
@@ -819,7 +819,7 @@ void HaierClimate::sendControlPacket(const ClimateCall* climateControl)
     }
     outData->disable_beeper = (!mBeeperEcho || (climateControl == NULL)) ? 1 : 0;
     controlOutBuffer[4] = 0;   // This byte should be cleared before setting values
-    outData->display_off = mDisplayStatus ? 0 : 1;
+    outData->display_status = mDisplayStatus ? 1 : 0;
     sendFrameWithSubcommand(HaierProtocol::ftControl, HaierProtocol::stControlSetGroupParameters, controlOutBuffer, sizeof(HaierPacketControl));
 }
 

--- a/components/haier/haier_climate.cpp
+++ b/components/haier/haier_climate.cpp
@@ -113,7 +113,7 @@ HaierClimate::HaierClimate(UARTComponent* parent) :
                                         mFanModeFanSpeed(FanMid),
                                         mOtherModesFanSpeed(FanAuto),
                                         mSendWifiSignal(false),
-                                        mBeeperEcho(true),
+                                        mBeeperStatus(true),
                                         mDisplayStatus(true),
                                         mForceSendControl(false),
                                         mHvacHardwareInfoAvailable(false),
@@ -180,12 +180,12 @@ void HaierClimate::set_send_wifi_signal(bool sendWifi)
 
 void HaierClimate::set_beeper_echo(bool beeper)
 {
-    mBeeperEcho = beeper;
+    mBeeperStatus = beeper;
 }
 
 bool HaierClimate::get_beeper_echo() const
 {
-    return mBeeperEcho;
+    return mBeeperStatus;
 }
 
 bool HaierClimate::get_display_state() const
@@ -817,7 +817,7 @@ void HaierClimate::sendControlPacket(const ClimateCall* climateControl)
         if (outData->horizontal_swing_mode != HorizontalSwingAuto)
             outData->horizontal_swing_mode = getHorizontalSwingMode(mHorizontalDirection);
     }
-    outData->disable_beeper = (!mBeeperEcho || (climateControl == NULL)) ? 1 : 0;
+    outData->beeper_status = (!mBeeperStatus || (climateControl == NULL)) ? 1 : 0;
     controlOutBuffer[4] = 0;   // This byte should be cleared before setting values
     outData->display_status = mDisplayStatus ? 1 : 0;
     sendFrameWithSubcommand(HaierProtocol::ftControl, HaierProtocol::stControlSetGroupParameters, controlOutBuffer, sizeof(HaierPacketControl));

--- a/components/haier/haier_climate.h
+++ b/components/haier/haier_climate.h
@@ -106,7 +106,7 @@ private:
     uint8_t                     mFanModeFanSpeed;
     uint8_t                     mOtherModesFanSpeed;
     bool                        mSendWifiSignal;
-    bool                        mBeeperEcho;
+    bool                        mBeeperStatus;
     bool                        mUseFahrenheit;
     bool                        mDisplayStatus;
     bool                        mForceSendControl;

--- a/components/haier/haier_packet.h
+++ b/components/haier/haier_packet.h
@@ -126,7 +126,7 @@ struct HaierPacketControl
                 uint8_t             ac_mode:3;                  // See enum ConditioningMode
     /* 13 */    uint8_t             :8;
     /* 14 */    uint8_t             ten_degree:1;               // 10 degree status
-                uint8_t             display_off:1;              // If the display is on or off
+                uint8_t             display_status:1;           // If 0 disables AC's display
                 uint8_t             half_degree:1;              // Use half degree
                 uint8_t             intelegence_status:1;       // Intelligence status
                 uint8_t             pmv_status:1;               // Comfort/PMV status               

--- a/components/haier/haier_packet.h
+++ b/components/haier/haier_packet.h
@@ -139,7 +139,7 @@ struct HaierPacketControl
                 uint8_t             quiet_mode:1;               // Quiet mode
                 uint8_t             sleep_mode:1;               // Sleep mode
                 uint8_t             lock_remote:1;              // Disable remote
-                uint8_t             disable_beeper:1;           // If 1 disables AC's command feedback beeper (need to be set on every control command)
+                uint8_t             beeper_status:1;            // If 1 disables AC's command feedback beeper (need to be set on every control command)
     /* 16 */    uint8_t             target_humidity;            // Target humidity (0=30% .. 3C=90%, step = 1%)
     /* 17 */    uint8_t             horizontal_swing_mode:3;    // See enum HorizontalSwingMode
                 uint8_t             :3;


### PR DESCRIPTION
In this PR I have inverted display status logic because it was working incorrectly: `off` in HA was `on` on AC and vice versa.
Also, renamed packet variable `disable_beeper` to `beeper_state` also according to the protocol documentation (just a cosmetics change).

Should I also rename beeper stuff in the python part (this will lead to incompatibility on the existing setups)?